### PR TITLE
docs: added installation method for Alpine systems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       postgres:
         image: postgres:9.6

--- a/README.md
+++ b/README.md
@@ -18,10 +18,18 @@ The following need to be installed in advance:
 
 ## Installation
 
-Ensure you have Casbin's system dependencies installed by:
+Ensure you have Casbin's system dependencies installed:
+
+- For systems having `apt` package manager:
 
 ```
 sudo apt install gcc libpcre3 libpcre3-dev
+```
+
+- For Alpine based systems:
+
+```
+sudo apk install gcc pcre pcre-dev libc-dev
 ```
 
 Install Casbin's latest release from LuaRocks by:


### PR DESCRIPTION
- Also fixed the test script to run on Ubuntu 20.04 since `ubuntu-latest` pulls the 22.04 version and Kong does not have the version we are using (2.5.0) for 22.04.

fix: #18 